### PR TITLE
Added new constant related to FAILED status

### DIFF
--- a/src/Hyperwallet/Model/User.php
+++ b/src/Hyperwallet/Model/User.php
@@ -83,6 +83,7 @@ class User extends BaseModel implements IProgramAware {
     const VERIFICATION_STATUS_NOT_REQUIRED = 'NOT_REQUIRED';
     const VERIFICATION_STATUS_UNDER_REVIEW = 'UNDER_REVIEW';
     const VERIFICATION_STATUS_VERIFIED = 'VERIFIED';
+    const VERIFICATION_STATUS_FAILED = 'FAILED';
 
     /**
      * Creates a instance of User


### PR DESCRIPTION
According to the API documentation, the property `verificationStatus` can have the value `FAILED`, but there is no correspondent constant with this status in the `src/Hyperwallet/Model/User.php` class. 