### PR TITLE
Fix randomly failing test

### DIFF
--- a/tests/Hyperwallet/Tests/Util/HyperwalletEncryptionTest.php
+++ b/tests/Hyperwallet/Tests/Util/HyperwalletEncryptionTest.php
@@ -37,7 +37,10 @@ class HyperwalletEncryptionTest extends \PHPUnit_Framework_TestCase {
             $encryption2->decrypt($encryptedMessage);
             $this->fail('Exception expected');
         } catch (\Exception $e) {
-            $this->assertEquals('Decryption error', $e->getMessage());
+            $this->assertThat($e->getMessage(), $this->logicalOr(
+                $this->equalTo('Decryption error'),
+                $this->equalTo('Ciphertext representative out of range')
+            ));
         }
     }
 

--- a/tests/Hyperwallet/Tests/Util/HyperwalletEncryptionTest.php
+++ b/tests/Hyperwallet/Tests/Util/HyperwalletEncryptionTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Hyperwallet\Tests;
+namespace Hyperwallet\Tests\Util;
 
 use Hyperwallet\Util\HyperwalletEncryption;
 use Hyperwallet\Exception\HyperwalletException;


### PR DESCRIPTION
This tests that the decrypt fails, but it fails to take into account one of the failure circumstances.

This fixes that by considering both failure exception messages.

Described in 
https://github.com/hyperwallet/php-sdk/pull/43