### PR TITLE
Fix filter limitation

### DIFF
--- a/src/Hyperwallet/Model/BankAccount.php
+++ b/src/Hyperwallet/Model/BankAccount.php
@@ -88,7 +88,7 @@ class BankAccount extends BaseModel {
     const PROFILE_TYPE_BUSINESS = 'BUSINESS';
 
     public static function FILTERS_ARRAY() {
-        return array('type','status');
+        return array('type','status','limit');
     }
 
 

--- a/tests/Hyperwallet/Tests/Util/HyperwalletEncryptionTest.php
+++ b/tests/Hyperwallet/Tests/Util/HyperwalletEncryptionTest.php
@@ -39,6 +39,7 @@ class HyperwalletEncryptionTest extends \PHPUnit_Framework_TestCase {
         } catch (\Exception $e) {
             $this->assertThat($e->getMessage(), $this->logicalOr(
                 $this->equalTo('Decryption error'),
+                $this->equalTo('Payload decryption failed'),
                 $this->equalTo('Ciphertext representative out of range')
             ));
         }


### PR DESCRIPTION
a request that contains the filters `status` and `limit` is valid according to the API.
however, the SDK blocks such requests.
this PR is proposing a fix for the issue