### PR TITLE
Add param type for $userToken, fixed warning on IDE

### DIFF
--- a/src/Hyperwallet/Hyperwallet.php
+++ b/src/Hyperwallet/Hyperwallet.php
@@ -215,7 +215,7 @@ class Hyperwallet {
     /**
      * Get authentication token
      *
-     * @param $userToken The user token
+     * @param string $userToken The user token
      * @return AuthenticationToken
      *
      * @throws HyperwalletApiException


### PR DESCRIPTION
As it is now, my IDE (PHPStorm) claims: Expected parameter of type '\Hyperwallet\The', 'string' provided