### PR TITLE
DTPAYWONE-568 Add missing webhook types

### DIFF
--- a/src/Hyperwallet/Model/WebhookNotification.php
+++ b/src/Hyperwallet/Model/WebhookNotification.php
@@ -60,6 +60,8 @@ class WebhookNotification extends BaseModel {
                 $this->object = new User($properties['object']);
             } else if (strpos($properties['type'], 'PAYMENTS') === 0) {
                 $this->object = new Payment($properties['object']);
+            } else if (strpos($properties['type'], 'TRANSFERS.REFUND') === 0) {
+                $this->object = new TransferRefund($properties['object']);
             } else if (strpos($properties['type'], 'TRANSFERS') === 0) {
                 $this->object = new Transfer($properties['object']);
             }

--- a/src/Hyperwallet/Model/WebhookNotification.php
+++ b/src/Hyperwallet/Model/WebhookNotification.php
@@ -46,6 +46,14 @@ class WebhookNotification extends BaseModel {
                 $this->object = new BankAccount($properties['object']);
             } else if (strpos($properties['type'], 'USERS.PREPAID_CARDS') === 0) {
                 $this->object = new PrepaidCard($properties['object']);
+            } else if (strpos($properties['type'], 'USERS.PAYPAL_ACCOUNTS') === 0) {
+                $this->object = new PayPalAccount($properties['object']);
+            } else if (strpos($properties['type'], 'USERS.VENMO_ACCOUNTS') === 0) {
+                $this->object = new VenmoAccount($properties['object']);
+            } else if (strpos($properties['type'], 'USERS.BANK_CARDS') === 0) {
+                $this->object = new BankCard($properties['object']);
+            } else if (strpos($properties['type'], 'USERS.PAPER_CHECKS') === 0) {
+                $this->object = new PaperCheck($properties['object']);
             } else if (strpos($properties['type'], 'USERS') === 0) {
                 $this->object = new User($properties['object']);
             } else if (strpos($properties['type'], 'PAYMENTS') === 0) {

--- a/src/Hyperwallet/Model/WebhookNotification.php
+++ b/src/Hyperwallet/Model/WebhookNotification.php
@@ -52,12 +52,16 @@ class WebhookNotification extends BaseModel {
                 $this->object = new VenmoAccount($properties['object']);
             } else if (strpos($properties['type'], 'USERS.BANK_CARDS') === 0) {
                 $this->object = new BankCard($properties['object']);
+            } else if (strpos($properties['type'], 'USERS.BUSINESS_STAKEHOLDERS') === 0) {
+                $this->object = new BusinessStakeholder($properties['object']);
             } else if (strpos($properties['type'], 'USERS.PAPER_CHECKS') === 0) {
                 $this->object = new PaperCheck($properties['object']);
             } else if (strpos($properties['type'], 'USERS') === 0) {
                 $this->object = new User($properties['object']);
             } else if (strpos($properties['type'], 'PAYMENTS') === 0) {
                 $this->object = new Payment($properties['object']);
+            } else if (strpos($properties['type'], 'TRANSFERS') === 0) {
+                $this->object = new Transfer($properties['object']);
             }
         }
     }

--- a/tests/Hyperwallet/Tests/Model/WebhookNotificationTest.php
+++ b/tests/Hyperwallet/Tests/Model/WebhookNotificationTest.php
@@ -15,11 +15,9 @@ use Hyperwallet\Model\User;
 use Hyperwallet\Model\VenmoAccount;
 use Hyperwallet\Model\WebhookNotification;
 
-class WebhookNotificationTest extends ModelTestCase
-{
+class WebhookNotificationTest extends ModelTestCase {
 
-    protected function getModelName()
-    {
+    protected function getModelName() {
         return 'WebhookNotification';
     }
 
@@ -28,8 +26,7 @@ class WebhookNotificationTest extends ModelTestCase
      *
      * @param string $property The property to look for
      */
-    public function testGettersForIgnoredProperties($property)
-    {
+    public function testGettersForIgnoredProperties($property) {
         $this->performGettersForIgnoredPropertiesTest($property);
     }
 
@@ -38,8 +35,7 @@ class WebhookNotificationTest extends ModelTestCase
      *
      * @param string $property The property to look for
      */
-    public function testGetterReturnValueIsSet($property)
-    {
+    public function testGetterReturnValueIsSet($property) {
         $this->performGetterReturnValueIsSetTest($property);
     }
 
@@ -48,8 +44,7 @@ class WebhookNotificationTest extends ModelTestCase
      *
      * @param string $property The property to look for
      */
-    public function testGetterReturnValueIsNotSet($property)
-    {
+    public function testGetterReturnValueIsNotSet($property) {
         $this->performGetterReturnValueIsNotSetTest($property);
     }
 
@@ -60,8 +55,7 @@ class WebhookNotificationTest extends ModelTestCase
      * @param object $clazz The expected class type
      *
      */
-    public function testConstructorObjectConversion($type, $clazz)
-    {
+    public function testConstructorObjectConversion($type, $clazz) {
         $data = array(
             'type' => $type,
             'test2' => 'value2',
@@ -83,8 +77,7 @@ class WebhookNotificationTest extends ModelTestCase
         }
     }
 
-    public function notificationTypeProvider()
-    {
+    public function notificationTypeProvider() {
         return array(
             'USERS.CREATED' => array('USERS.CREATED', User::class),
             'USERS.UPDATED.STATUS.ACTIVATED' => array('USERS.UPDATED.STATUS.ACTIVATED', User::class),

--- a/tests/Hyperwallet/Tests/Model/WebhookNotificationTest.php
+++ b/tests/Hyperwallet/Tests/Model/WebhookNotificationTest.php
@@ -10,6 +10,7 @@ use Hyperwallet\Model\Payment;
 use Hyperwallet\Model\PayPalAccount;
 use Hyperwallet\Model\PrepaidCard;
 use Hyperwallet\Model\Transfer;
+use Hyperwallet\Model\TransferRefund;
 use Hyperwallet\Model\User;
 use Hyperwallet\Model\VenmoAccount;
 use Hyperwallet\Model\WebhookNotification;
@@ -151,6 +152,9 @@ class WebhookNotificationTest extends ModelTestCase
             'TRANSFERS.UPDATED.STATUS.IN_PROGRESS' => array('TRANSFERS.UPDATED.STATUS.IN_PROGRESS', Transfer::class),
             'TRANSFERS.UPDATED.STATUS.COMPLETED' => array('TRANSFERS.UPDATED.STATUS.COMPLETED', Transfer::class),
             'TRANSFERS.UPDATED.STATUS.FAILED' => array('TRANSFERS.UPDATED.STATUS.FAILED', Transfer::class),
+
+            'TRANSFERS.REFUND.CREATED' => array('TRANSFERS.REFUND.CREATED', TransferRefund::class),
+            'TRANSFERS.REFUND.UPDATED' => array('TRANSFERS.REFUND.UPDATED', TransferRefund::class),
 
             'TEST' => array('TEST', null),
         );

--- a/tests/Hyperwallet/Tests/Model/WebhookNotificationTest.php
+++ b/tests/Hyperwallet/Tests/Model/WebhookNotificationTest.php
@@ -1,19 +1,24 @@
 <?php
+
 namespace Hyperwallet\Tests\Model;
 
 use Hyperwallet\Model\BankAccount;
 use Hyperwallet\Model\BankCard;
+use Hyperwallet\Model\BusinessStakeholder;
 use Hyperwallet\Model\PaperCheck;
 use Hyperwallet\Model\Payment;
 use Hyperwallet\Model\PayPalAccount;
 use Hyperwallet\Model\PrepaidCard;
+use Hyperwallet\Model\Transfer;
 use Hyperwallet\Model\User;
 use Hyperwallet\Model\VenmoAccount;
 use Hyperwallet\Model\WebhookNotification;
 
-class WebhookNotificationTest extends ModelTestCase {
+class WebhookNotificationTest extends ModelTestCase
+{
 
-    protected function getModelName() {
+    protected function getModelName()
+    {
         return 'WebhookNotification';
     }
 
@@ -22,7 +27,8 @@ class WebhookNotificationTest extends ModelTestCase {
      *
      * @param string $property The property to look for
      */
-    public function testGettersForIgnoredProperties($property) {
+    public function testGettersForIgnoredProperties($property)
+    {
         $this->performGettersForIgnoredPropertiesTest($property);
     }
 
@@ -31,7 +37,8 @@ class WebhookNotificationTest extends ModelTestCase {
      *
      * @param string $property The property to look for
      */
-    public function testGetterReturnValueIsSet($property) {
+    public function testGetterReturnValueIsSet($property)
+    {
         $this->performGetterReturnValueIsSetTest($property);
     }
 
@@ -40,7 +47,8 @@ class WebhookNotificationTest extends ModelTestCase {
      *
      * @param string $property The property to look for
      */
-    public function testGetterReturnValueIsNotSet($property) {
+    public function testGetterReturnValueIsNotSet($property)
+    {
         $this->performGetterReturnValueIsNotSetTest($property);
     }
 
@@ -51,7 +59,8 @@ class WebhookNotificationTest extends ModelTestCase {
      * @param object $clazz The expected class type
      *
      */
-    public function testConstructorObjectConversion($type, $clazz) {
+    public function testConstructorObjectConversion($type, $clazz)
+    {
         $data = array(
             'type' => $type,
             'test2' => 'value2',
@@ -73,13 +82,21 @@ class WebhookNotificationTest extends ModelTestCase {
         }
     }
 
-    public function notificationTypeProvider() {
+    public function notificationTypeProvider()
+    {
         return array(
             'USERS.CREATED' => array('USERS.CREATED', User::class),
             'USERS.UPDATED.STATUS.ACTIVATED' => array('USERS.UPDATED.STATUS.ACTIVATED', User::class),
             'USERS.UPDATED.STATUS.LOCKED' => array('USERS.UPDATED.STATUS.LOCKED', User::class),
             'USERS.UPDATED.STATUS.FROZEN' => array('USERS.UPDATED.STATUS.FROZEN', User::class),
             'USERS.UPDATED.STATUS.DE_ACTIVATED' => array('USERS.UPDATED.STATUS.DE_ACTIVATED', User::class),
+
+            'USERS.BUSINESS_STAKEHOLDERS.UPDATED.VERIFICATION_STATUS.REQUIRED' => array('USERS.BUSINESS_STAKEHOLDERS.UPDATED.VERIFICATION_STATUS.REQUIRED', BusinessStakeholder::class),
+            'USERS.BUSINESS_STAKEHOLDERS.UPDATED.VERIFICATION_STATUS.UNDER_REVIEW' => array('USERS.BUSINESS_STAKEHOLDERS.UPDATED.VERIFICATION_STATUS.UNDER_REVIEW', BusinessStakeholder::class),
+            'USERS.BUSINESS_STAKEHOLDERS.UPDATED.VERIFICATION_STATUS.VERIFIED' => array('USERS.BUSINESS_STAKEHOLDERS.UPDATED.VERIFICATION_STATUS.VERIFIED', BusinessStakeholder::class),
+            'USERS.BUSINESS_STAKEHOLDERS.UPDATED.VERIFICATION_STATUS.NOT_REQUIRED' => array('USERS.BUSINESS_STAKEHOLDERS.UPDATED.VERIFICATION_STATUS.NOT_REQUIRED', BusinessStakeholder::class),
+            'USERS.BUSINESS_STAKEHOLDERS.CREATED' => array('USERS.BUSINESS_STAKEHOLDERS.CREATED', BusinessStakeholder::class),
+            'USERS.BUSINESS_STAKEHOLDERS.UPDATED.STATUS.DE_ACTIVATED' => array('USERS.BUSINESS_STAKEHOLDERS.UPDATED.STATUS.DE_ACTIVATED', BusinessStakeholder::class),
 
             'USERS.BANK_ACCOUNTS.CREATED' => array('USERS.BANK_ACCOUNTS.CREATED', BankAccount::class),
             'USERS.BANK_ACCOUNTS.UPDATED.STATUS.ACTIVATED' => array('USERS.BANK_ACCOUNTS.UPDATED.STATUS.ACTIVATED', BankAccount::class),
@@ -124,6 +141,16 @@ class WebhookNotificationTest extends ModelTestCase {
             'USERS.PAPER_CHECKS.UPDATED.STATUS.INVALID' => array('USERS.PAPER_CHECKS.UPDATED.STATUS.INVALID', PaperCheck::class),
 
             'PAYMENTS.CREATED' => array('PAYMENTS.CREATED', Payment::class),
+            'PAYMENTS.UPDATED.STATUS.SCHEDULED' => array('PAYMENTS.UPDATED.STATUS.SCHEDULED', Payment::class),
+            'PAYMENTS.UPDATED.STATUS.PENDING_ACCOUNT_ACTIVATION' => array('PAYMENTS.UPDATED.STATUS.PENDING_ACCOUNT_ACTIVATION', Payment::class),
+            'PAYMENTS.UPDATED.STATUS.PENDING_ID_VERIFICATION' => array('PAYMENTS.UPDATED.STATUS.PENDING_ID_VERIFICATION', Payment::class),
+            'PAYMENTS.UPDATED.STATUS.PENDING_TAX_VERIFICATION' => array('PAYMENTS.UPDATED.STATUS.PENDING_TAX_VERIFICATION', Payment::class),
+
+
+            'TRANSFERS.UPDATED.STATUS.SCHEDULED' => array('TRANSFERS.UPDATED.STATUS.SCHEDULED', Transfer::class),
+            'TRANSFERS.UPDATED.STATUS.IN_PROGRESS' => array('TRANSFERS.UPDATED.STATUS.IN_PROGRESS', Transfer::class),
+            'TRANSFERS.UPDATED.STATUS.COMPLETED' => array('TRANSFERS.UPDATED.STATUS.COMPLETED', Transfer::class),
+            'TRANSFERS.UPDATED.STATUS.FAILED' => array('TRANSFERS.UPDATED.STATUS.FAILED', Transfer::class),
 
             'TEST' => array('TEST', null),
         );

--- a/tests/Hyperwallet/Tests/Model/WebhookNotificationTest.php
+++ b/tests/Hyperwallet/Tests/Model/WebhookNotificationTest.php
@@ -2,9 +2,13 @@
 namespace Hyperwallet\Tests\Model;
 
 use Hyperwallet\Model\BankAccount;
+use Hyperwallet\Model\BankCard;
+use Hyperwallet\Model\PaperCheck;
 use Hyperwallet\Model\Payment;
+use Hyperwallet\Model\PayPalAccount;
 use Hyperwallet\Model\PrepaidCard;
 use Hyperwallet\Model\User;
+use Hyperwallet\Model\VenmoAccount;
 use Hyperwallet\Model\WebhookNotification;
 
 class WebhookNotificationTest extends ModelTestCase {
@@ -93,6 +97,31 @@ class WebhookNotificationTest extends ModelTestCase {
             'USERS.PREPAID_CARDS.UPDATED.STATUS.DE_ACTIVATED' => array('USERS.PREPAID_CARDS.UPDATED.STATUS.DE_ACTIVATED', PrepaidCard::class),
             'USERS.PREPAID_CARDS.UPDATED.STATUS.COMPLIANCE_HOLD' => array('USERS.PREPAID_CARDS.UPDATED.STATUS.COMPLIANCE_HOLD', PrepaidCard::class),
             'USERS.PREPAID_CARDS.UPDATED.STATUS.KYC_HOLD' => array('USERS.PREPAID_CARDS.UPDATED.STATUS.KYC_HOLD', PrepaidCard::class),
+
+            'USERS.PAYPAL_ACCOUNTS.CREATED' => array('USERS.PAYPAL_ACCOUNTS.CREATED', PayPalAccount::class),
+            'USERS.PAYPAL_ACCOUNTS.UPDATED.STATUS.ACTIVATED' => array('USERS.PAYPAL_ACCOUNTS.UPDATED.STATUS.ACTIVATED', PayPalAccount::class),
+            'USERS.PAYPAL_ACCOUNTS.UPDATED.STATUS.DE_ACTIVATED' => array('USERS.PAYPAL_ACCOUNTS.UPDATED.STATUS.DE_ACTIVATED', PayPalAccount::class),
+            'USERS.PAYPAL_ACCOUNTS.UPDATED.STATUS.VERIFIED' => array('USERS.PAYPAL_ACCOUNTS.UPDATED.STATUS.VERIFIED', PayPalAccount::class),
+            'USERS.PAYPAL_ACCOUNTS.UPDATED.STATUS.INVALID' => array('USERS.PAYPAL_ACCOUNTS.UPDATED.STATUS.INVALID', PayPalAccount::class),
+
+            'USERS.VENMO_ACCOUNTS.CREATED' => array('USERS.VENMO_ACCOUNTS.CREATED', VenmoAccount::class),
+            'USERS.VENMO_ACCOUNTS.UPDATED.STATUS.ACTIVATED' => array('USERS.VENMO_ACCOUNTS.UPDATED.STATUS.ACTIVATED', VenmoAccount::class),
+            'USERS.VENMO_ACCOUNTS.UPDATED.STATUS.DE_ACTIVATED' => array('USERS.VENMO_ACCOUNTS.UPDATED.STATUS.DE_ACTIVATED', VenmoAccount::class),
+            'USERS.VENMO_ACCOUNTS.UPDATED.STATUS.VERIFIED' => array('USERS.VENMO_ACCOUNTS.UPDATED.STATUS.VERIFIED', VenmoAccount::class),
+            'USERS.VENMO_ACCOUNTS.UPDATED.STATUS.INVALID' => array('USERS.VENMO_ACCOUNTS.UPDATED.STATUS.INVALID', VenmoAccount::class),
+
+            'USERS.BANK_CARDS.CREATED' => array('USERS.BANK_CARDS.CREATED', BankCard::class),
+            'USERS.BANK_CARDS.UPDATED.STATUS.ACTIVATED' => array('USERS.BANK_CARDS.UPDATED.STATUS.ACTIVATED', BankCard::class),
+            'USERS.BANK_CARDS.UPDATED.STATUS.DE_ACTIVATED' => array('USERS.BANK_CARDS.UPDATED.STATUS.DE_ACTIVATED', BankCard::class),
+            'USERS.BANK_CARDS.UPDATED.STATUS.VERIFIED' => array('USERS.BANK_CARDS.UPDATED.STATUS.VERIFIED', BankCard::class),
+            'USERS.BANK_CARDS.UPDATED.STATUS.INVALID' => array('USERS.BANK_CARDS.UPDATED.STATUS.INVALID', BankCard::class),
+
+            'USERS.PAPER_CHECKS.CREATED' => array('USERS.PAPER_CHECKS.CREATED', PaperCheck::class),
+            'USERS.PAPER_CHECKS.UPDATED' => array('USERS.PAPER_CHECKS.UPDATED', PaperCheck::class),
+            'USERS.PAPER_CHECKS.UPDATED.STATUS.ACTIVATED' => array('USERS.PAPER_CHECKS.UPDATED.STATUS.ACTIVATED', PaperCheck::class),
+            'USERS.PAPER_CHECKS.UPDATED.STATUS.DE_ACTIVATED' => array('USERS.PAPER_CHECKS.UPDATED.STATUS.DE_ACTIVATED', PaperCheck::class),
+            'USERS.PAPER_CHECKS.UPDATED.STATUS.VERIFIED' => array('USERS.PAPER_CHECKS.UPDATED.STATUS.VERIFIED', PaperCheck::class),
+            'USERS.PAPER_CHECKS.UPDATED.STATUS.INVALID' => array('USERS.PAPER_CHECKS.UPDATED.STATUS.INVALID', PaperCheck::class),
 
             'PAYMENTS.CREATED' => array('PAYMENTS.CREATED', Payment::class),
 


### PR DESCRIPTION
Jira ticket : DTPAYWONE-568

- Add missing webhook type     
- BANK_CARDS
- PAYPAL_ACCOUNTS
- PAPER_CHECKS: PaperCheck
- VENMO_ACCOUNTS
- TRANSFERS
-  BUSINESS_STAKEHOLDERS
-  REFUND