### PR TITLE
DTPAYWONE-568 Add missing webhook types for V3

### DIFF
--- a/src/Hyperwallet/Model/WebhookNotification.php
+++ b/src/Hyperwallet/Model/WebhookNotification.php
@@ -46,10 +46,22 @@ class WebhookNotification extends BaseModel {
                 $this->object = new BankAccount($properties['object']);
             } else if (strpos($properties['type'], 'USERS.PREPAID_CARDS') === 0) {
                 $this->object = new PrepaidCard($properties['object']);
+            } else if (strpos($properties['type'], 'USERS.PAYPAL_ACCOUNTS') === 0) {
+                $this->object = new PayPalAccount($properties['object']);
+            } else if (strpos($properties['type'], 'USERS.VENMO_ACCOUNTS') === 0) {
+                $this->object = new VenmoAccount($properties['object']);
+            } else if (strpos($properties['type'], 'USERS.BANK_CARDS') === 0) {
+                $this->object = new BankCard($properties['object']);
+            } else if (strpos($properties['type'], 'USERS.PAPER_CHECKS') === 0) {
+                $this->object = new PaperCheck($properties['object']);
             } else if (strpos($properties['type'], 'USERS') === 0) {
                 $this->object = new User($properties['object']);
             } else if (strpos($properties['type'], 'PAYMENTS') === 0) {
                 $this->object = new Payment($properties['object']);
+            } else if (strpos($properties['type'], 'TRANSFERS.REFUND') === 0) {
+                $this->object = new TransferRefund($properties['object']);
+            } else if (strpos($properties['type'], 'TRANSFERS') === 0) {
+                $this->object = new Transfer($properties['object']);
             }
         }
     }

--- a/tests/Hyperwallet/Tests/Model/WebhookNotificationTest.php
+++ b/tests/Hyperwallet/Tests/Model/WebhookNotificationTest.php
@@ -2,9 +2,15 @@
 namespace Hyperwallet\Tests\Model;
 
 use Hyperwallet\Model\BankAccount;
+use Hyperwallet\Model\BankCard;
+use Hyperwallet\Model\PaperCheck;
 use Hyperwallet\Model\Payment;
+use Hyperwallet\Model\PayPalAccount;
 use Hyperwallet\Model\PrepaidCard;
+use Hyperwallet\Model\Transfer;
+use Hyperwallet\Model\TransferRefund;
 use Hyperwallet\Model\User;
+use Hyperwallet\Model\VenmoAccount;
 use Hyperwallet\Model\WebhookNotification;
 
 class WebhookNotificationTest extends ModelTestCase {
@@ -94,7 +100,45 @@ class WebhookNotificationTest extends ModelTestCase {
             'USERS.PREPAID_CARDS.UPDATED.STATUS.COMPLIANCE_HOLD' => array('USERS.PREPAID_CARDS.UPDATED.STATUS.COMPLIANCE_HOLD', PrepaidCard::class),
             'USERS.PREPAID_CARDS.UPDATED.STATUS.KYC_HOLD' => array('USERS.PREPAID_CARDS.UPDATED.STATUS.KYC_HOLD', PrepaidCard::class),
 
+            'USERS.PAYPAL_ACCOUNTS.CREATED' => array('USERS.PAYPAL_ACCOUNTS.CREATED', PayPalAccount::class),
+            'USERS.PAYPAL_ACCOUNTS.UPDATED.STATUS.ACTIVATED' => array('USERS.PAYPAL_ACCOUNTS.UPDATED.STATUS.ACTIVATED', PayPalAccount::class),
+            'USERS.PAYPAL_ACCOUNTS.UPDATED.STATUS.DE_ACTIVATED' => array('USERS.PAYPAL_ACCOUNTS.UPDATED.STATUS.DE_ACTIVATED', PayPalAccount::class),
+            'USERS.PAYPAL_ACCOUNTS.UPDATED.STATUS.VERIFIED' => array('USERS.PAYPAL_ACCOUNTS.UPDATED.STATUS.VERIFIED', PayPalAccount::class),
+            'USERS.PAYPAL_ACCOUNTS.UPDATED.STATUS.INVALID' => array('USERS.PAYPAL_ACCOUNTS.UPDATED.STATUS.INVALID', PayPalAccount::class),
+
+            'USERS.VENMO_ACCOUNTS.CREATED' => array('USERS.VENMO_ACCOUNTS.CREATED', VenmoAccount::class),
+            'USERS.VENMO_ACCOUNTS.UPDATED.STATUS.ACTIVATED' => array('USERS.VENMO_ACCOUNTS.UPDATED.STATUS.ACTIVATED', VenmoAccount::class),
+            'USERS.VENMO_ACCOUNTS.UPDATED.STATUS.DE_ACTIVATED' => array('USERS.VENMO_ACCOUNTS.UPDATED.STATUS.DE_ACTIVATED', VenmoAccount::class),
+            'USERS.VENMO_ACCOUNTS.UPDATED.STATUS.VERIFIED' => array('USERS.VENMO_ACCOUNTS.UPDATED.STATUS.VERIFIED', VenmoAccount::class),
+            'USERS.VENMO_ACCOUNTS.UPDATED.STATUS.INVALID' => array('USERS.VENMO_ACCOUNTS.UPDATED.STATUS.INVALID', VenmoAccount::class),
+
+            'USERS.BANK_CARDS.CREATED' => array('USERS.BANK_CARDS.CREATED', BankCard::class),
+            'USERS.BANK_CARDS.UPDATED.STATUS.ACTIVATED' => array('USERS.BANK_CARDS.UPDATED.STATUS.ACTIVATED', BankCard::class),
+            'USERS.BANK_CARDS.UPDATED.STATUS.DE_ACTIVATED' => array('USERS.BANK_CARDS.UPDATED.STATUS.DE_ACTIVATED', BankCard::class),
+            'USERS.BANK_CARDS.UPDATED.STATUS.VERIFIED' => array('USERS.BANK_CARDS.UPDATED.STATUS.VERIFIED', BankCard::class),
+            'USERS.BANK_CARDS.UPDATED.STATUS.INVALID' => array('USERS.BANK_CARDS.UPDATED.STATUS.INVALID', BankCard::class),
+
+            'USERS.PAPER_CHECKS.CREATED' => array('USERS.PAPER_CHECKS.CREATED', PaperCheck::class),
+            'USERS.PAPER_CHECKS.UPDATED' => array('USERS.PAPER_CHECKS.UPDATED', PaperCheck::class),
+            'USERS.PAPER_CHECKS.UPDATED.STATUS.ACTIVATED' => array('USERS.PAPER_CHECKS.UPDATED.STATUS.ACTIVATED', PaperCheck::class),
+            'USERS.PAPER_CHECKS.UPDATED.STATUS.DE_ACTIVATED' => array('USERS.PAPER_CHECKS.UPDATED.STATUS.DE_ACTIVATED', PaperCheck::class),
+            'USERS.PAPER_CHECKS.UPDATED.STATUS.VERIFIED' => array('USERS.PAPER_CHECKS.UPDATED.STATUS.VERIFIED', PaperCheck::class),
+            'USERS.PAPER_CHECKS.UPDATED.STATUS.INVALID' => array('USERS.PAPER_CHECKS.UPDATED.STATUS.INVALID', PaperCheck::class),
+
             'PAYMENTS.CREATED' => array('PAYMENTS.CREATED', Payment::class),
+            'PAYMENTS.UPDATED.STATUS.SCHEDULED' => array('PAYMENTS.UPDATED.STATUS.SCHEDULED', Payment::class),
+            'PAYMENTS.UPDATED.STATUS.PENDING_ACCOUNT_ACTIVATION' => array('PAYMENTS.UPDATED.STATUS.PENDING_ACCOUNT_ACTIVATION', Payment::class),
+            'PAYMENTS.UPDATED.STATUS.PENDING_ID_VERIFICATION' => array('PAYMENTS.UPDATED.STATUS.PENDING_ID_VERIFICATION', Payment::class),
+            'PAYMENTS.UPDATED.STATUS.PENDING_TAX_VERIFICATION' => array('PAYMENTS.UPDATED.STATUS.PENDING_TAX_VERIFICATION', Payment::class),
+
+
+            'TRANSFERS.UPDATED.STATUS.SCHEDULED' => array('TRANSFERS.UPDATED.STATUS.SCHEDULED', Transfer::class),
+            'TRANSFERS.UPDATED.STATUS.IN_PROGRESS' => array('TRANSFERS.UPDATED.STATUS.IN_PROGRESS', Transfer::class),
+            'TRANSFERS.UPDATED.STATUS.COMPLETED' => array('TRANSFERS.UPDATED.STATUS.COMPLETED', Transfer::class),
+            'TRANSFERS.UPDATED.STATUS.FAILED' => array('TRANSFERS.UPDATED.STATUS.FAILED', Transfer::class),
+
+            'TRANSFERS.REFUND.CREATED' => array('TRANSFERS.REFUND.CREATED', TransferRefund::class),
+            'TRANSFERS.REFUND.UPDATED' => array('TRANSFERS.REFUND.UPDATED', TransferRefund::class),
 
             'TEST' => array('TEST', null),
         );


### PR DESCRIPTION
Jira ticket: DTPAYWONE-568

- BussinessStakeHolder Model does not exist in V3
- Add missing webhook type

 BANK_CARDS
 PAYPAL_ACCOUNTS
 PAPER_CHECKS: PaperCheck
 VENMO_ACCOUNTS
 TRANSFERS
 REFUND
