### PR TITLE
PPPLMER-105096: (Bug Fix) Addressing key accessing errors for non-existing keys

### DIFF
--- a/src/Hyperwallet/Hyperwallet.php
+++ b/src/Hyperwallet/Hyperwallet.php
@@ -95,11 +95,11 @@ class Hyperwallet {
      * @return array
      */
     private function setDocumentAndReasonFromResponseHelper($bodyResponse) {
-        $documents = $bodyResponse["documents"];
-        if ($documents) {
+        if (array_key_exists("documents", $bodyResponse)) {
+            $documents = $bodyResponse["documents"];
             foreach ($documents as &$dVal) {
-                $reasons = $dVal["reasons"];
-                if ($reasons) {
+                if (array_key_exists("reasons", $dVal)) {
+                    $reasons = $dVal["reasons"];
                     foreach ($reasons as &$rVal) {
                         $rVal = new HyperwalletVerificationDocumentReason($rVal);
                     }

--- a/tests/Hyperwallet/Tests/HyperwalletTest.php
+++ b/tests/Hyperwallet/Tests/HyperwalletTest.php
@@ -4297,6 +4297,26 @@ class HyperwalletTest extends \PHPUnit_Framework_TestCase {
         );
     }
 
+    public static function UPLOAD_REASON_DATA_NO_REASON() {
+        return array(
+            'token' => 'tkn-12345',
+            "documents" => array( array(
+                "category" => "IDENTIFICATION",
+                "type" => "PASSPORT",
+                "country" => "ES",
+                "status" => "NEW",
+                "createdOn" => "2020-11-24T19:05:02"
+
+            ))
+        );
+    }
+
+    public static function UPLOAD_REASON_DATA_NO_DOC() {
+        return array(
+            'token' => 'tkn-12345',
+        );
+    }
+
     public function testuploadDocumentsForUser_withoutUserToken() {
         // Setup
         $client = new Hyperwallet('test-username', 'test-password');
@@ -4410,6 +4430,75 @@ class HyperwalletTest extends \PHPUnit_Framework_TestCase {
         $this->assertNotNull($newUser);
         $this->assertNull($newUser->getProgramToken());
         $this->assertEquals($this->UPLOAD_REASON_DATA()["documents"][0]["type"], $newUser->documents->documents[0]->type);
+
+        // Validate mock
+        \Phake::verify($apiClientMock)->putMultipartData('/rest/v4/users/{user-token}', array('user-token' => $userToken), $options);
+    }
+
+    public function testuploadDocumentsForUser_parseNoReasons() {
+        // Setup
+        $client = new Hyperwallet('test-username', 'test-password');
+        $apiClientMock = $this->createAndInjectApiClientMock($client);
+        $userToken = "user-token";
+
+        $options = array(
+            'multipart' => [
+                [
+                    'name'     => 'data',
+                    'contents' => '{"documents":[{"type":"DRIVERS_LICENSE","country":"AL","category":"IDENTIFICATION"}]}'
+                ],
+                [
+                    'name'     => 'drivers_license_front',
+                    'contents' => fopen(__DIR__ . "/../../resources/license-front.png", "r")
+                ],
+                [
+                    'name'     => 'drivers_license_back',
+                    'contents' => fopen(__DIR__ . "/../../resources/license-back.png", 'r')
+                ]
+            ]
+        );
+
+        \Phake::when($apiClientMock)->putMultipartData('/rest/v4/users/{user-token}', array('user-token' => $userToken), $options)->thenReturn($this->UPLOAD_REASON_DATA_NO_REASON());
+        // Run test
+        $newUser = $client->uploadDocumentsForUser($userToken, $options);
+        $this->assertNotNull($newUser);
+        $this->assertNull($newUser->getProgramToken());
+        $this->assertEquals($this->UPLOAD_REASON_DATA_NO_REASON()["documents"][0]["type"], $newUser->documents->documents[0]->type);
+
+        // Validate mock
+        \Phake::verify($apiClientMock)->putMultipartData('/rest/v4/users/{user-token}', array('user-token' => $userToken), $options);
+    }
+
+    public function testuploadDocumentsForUser_parseNoDocument() {
+        // Setup
+        $client = new Hyperwallet('test-username', 'test-password');
+        $apiClientMock = $this->createAndInjectApiClientMock($client);
+        $userToken = "user-token";
+
+        $options = array(
+            'multipart' => [
+                [
+                    'name'     => 'data',
+                    'contents' => '{"documents":[{"type":"DRIVERS_LICENSE","country":"AL","category":"IDENTIFICATION"}]}'
+                ],
+                [
+                    'name'     => 'drivers_license_front',
+                    'contents' => fopen(__DIR__ . "/../../resources/license-front.png", "r")
+                ],
+                [
+                    'name'     => 'drivers_license_back',
+                    'contents' => fopen(__DIR__ . "/../../resources/license-back.png", 'r')
+                ]
+            ]
+        );
+
+        \Phake::when($apiClientMock)->putMultipartData('/rest/v4/users/{user-token}', array('user-token' => $userToken), $options)->thenReturn($this->UPLOAD_REASON_DATA_NO_DOC());
+
+        // Run test
+        $newUser = $client->uploadDocumentsForUser($userToken, $options);
+        $this->assertNotNull($newUser);
+        $this->assertNull($newUser->getProgramToken());
+        $this->assertEquals($this->UPLOAD_REASON_DATA_NO_DOC()["token"], $newUser->token);
 
         // Validate mock
         \Phake::verify($apiClientMock)->putMultipartData('/rest/v4/users/{user-token}', array('user-token' => $userToken), $options);


### PR DESCRIPTION
Ticket: https://engineering.paypalcorp.com/jira/browse/PPPLMER-105096

Changes:

- Added test to cover cases where certain fields do not exist
- Modified formatting helper function to do boolean validation before attempting data access

Note: had to enable error strictness in order to see error logs
`error_reporting(-1);`

Tests:

Original tests with errors enabled:
<img width="1792" alt="Screen Shot 2022-03-23 at 11 44 19 AM" src="https://user-images.githubusercontent.com/91630355/159778339-8a08d725-123d-4a4c-b4bd-042c319c4aa6.png">


Current Tests:
<img width="1792" alt="Screen Shot 2022-03-23 at 11 24 52 AM" src="https://user-images.githubusercontent.com/91630355/159778374-3a31e5ad-aafe-49e7-a5d3-9dd8b2cf5880.png">

