### PR TITLE
PPPLMER-105096: (Bug Fix) v3  Addressing key accessing errors for non-existing keys

### DIFF
--- a/src/Hyperwallet/Hyperwallet.php
+++ b/src/Hyperwallet/Hyperwallet.php
@@ -91,11 +91,11 @@ class Hyperwallet {
      * @return array
      */
     private function setDocumentAndReasonFromResponseHelper($bodyResponse) {
-        $documents = $bodyResponse["documents"];
-        if ($documents) {
+        if (array_key_exists("documents", $bodyResponse)) {
+            $documents = $bodyResponse["documents"];
             foreach ($documents as &$dVal) {
-                $reasons = $dVal["reasons"];
-                if ($reasons) {
+                if (array_key_exists("reasons", $dVal)) {
+                    $reasons = $dVal["reasons"];
                     foreach ($reasons as &$rVal) {
                         $rVal = new HyperwalletVerificationDocumentReason($rVal);
                     }


### PR DESCRIPTION
Ticket: https://engineering.paypalcorp.com/jira/browse/PPPLMER-105096

Changes:

Added test to cover cases where certain fields do not exist
Modified formatting helper function to do boolean validation before attempting data access
Note: had to enable error strictness in order to see error logs
error_reporting(-1);

Tests:
<img width="1792" alt="Screen Shot 2022-03-23 at 2 15 36 PM" src="https://user-images.githubusercontent.com/91630355/159797624-6db0bad4-8fab-4b4a-8081-b9ca3609d86e.png">

