### PR TITLE
feature/DTSERWONE-1083 - V3 Support php versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,80 @@
+name: PHP SDK CI
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+      - support/SDK-V3
+      - feature/**
+      - bugfix/**
+  pull_request:
+    branches:
+      - master
+      - support/SDK-V3
+      - feature/**
+      - bugfix/**
+
+jobs:
+  tests:
+    name: Tests
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      fail-fast: false
+      matrix:
+        operating-system: ['ubuntu-latest']
+        php-versions: ['5.6', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
+
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+          coverage: xdebug
+
+      - name: Validate composer.json and composer.lock
+        run: composer validate
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress --no-suggest
+
+      - name: Run test suite
+        run: |
+          php --version
+          ./vendor/bin/phpunit -v
+
+  code-coverage:
+    name: Report code coverage
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      fail-fast: false
+      matrix:
+        operating-system: [ 'ubuntu-latest' ]
+        php-versions: [ '5.6' ]
+
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+          coverage: xdebug
+
+      - name: Validate composer.json and composer.lock
+        run: composer validate
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress --no-suggest
+
+      - name: Run test suite
+        run: |
+          php --version
+          ./vendor/bin/phpunit -v
+
+      - name: Upload coverage results to Coveralls
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./vendor/bin/php-coveralls -v --exclude-no-stmt

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "creditcard",
     "ach"
   ],
-  "homepage": "http://hyperwallet.github.io/php-sdk",
+  "homepage": "https://github.com/hyperwallet/php-sdk",
   "license": "MIT",
   "authors": [
     {
@@ -20,9 +20,9 @@
     }
   ],
   "require": {
-    "php": ">=5.5.9",
+    "php": ">=5.6.0",
+    "ext-json": "*",
     "guzzlehttp/guzzle": "^6.2.1 || ^7.0.1",
-    "guzzlehttp/uri-template": "^0.2.0",
     "phpseclib/phpseclib": "^2.0.11",
     "gree/jose": "^2.2.1"
   },
@@ -33,9 +33,9 @@
     "psr-4": { "Hyperwallet\\Tests\\" : "tests/Hyperwallet/Tests", "ComposerScript\\" : "src/ComposerScript" }
   },
   "require-dev": {
-    "phpunit/phpunit": "^4.8",
-    "phake/phake": "^2.3",
-    "satooshi/php-coveralls": "^1.0"
+    "phpunit/phpunit": "^5.7 || ^7.0.0 || ^9.0",
+    "phake/phake": "^2.3 || ^4.2",
+    "php-coveralls/php-coveralls": "^2.5"
   },
   "scripts": {
     "post-install-cmd": "ComposerScript\\RsaOaep256AlgorithmInstaller::install"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
          bootstrap="vendor/autoload.php"
 >
     <testsuites>
@@ -21,4 +20,7 @@
             <directory>./src</directory>
         </whitelist>
     </filter>
+    <logging>
+        <log type="coverage-clover" target="build/logs/clover.xml"/>
+    </logging>
 </phpunit>

--- a/src/Hyperwallet/Exception/HyperwalletApiException.php
+++ b/src/Hyperwallet/Exception/HyperwalletApiException.php
@@ -31,7 +31,7 @@ class HyperwalletApiException extends HyperwalletException {
      */
     public function __construct(ErrorResponse $errorResponse, \Exception $previous) {
         $message = $errorResponse[0] == null ? "Error message is not defined" : $errorResponse[0]->getMessage();
-        parent::__construct($message, null, $previous);
+        parent::__construct($message, 0, $previous);
 
         $this->errorResponse = $errorResponse;
         $this->relatedResources = $errorResponse[0] == null ? array() : $errorResponse[0]->getRelatedResources();

--- a/src/Hyperwallet/Exception/HyperwalletArgumentException.php
+++ b/src/Hyperwallet/Exception/HyperwalletArgumentException.php
@@ -12,10 +12,10 @@ class HyperwalletArgumentException extends HyperwalletException {
      * Creates a instance of the HyperwalletArgumentException
      *
      * @param string $message The error message
-     * @param int|null $code The error code
+     * @param int $code The error code
      * @param \Exception|null $previous The original exception
      */
-    public function __construct($message, $code = null, \Exception $previous = null) {
+    public function __construct($message, $code = 0, \Exception $previous = null) {
         parent::__construct($message, $code, $previous);
     }
 

--- a/src/Hyperwallet/Exception/HyperwalletException.php
+++ b/src/Hyperwallet/Exception/HyperwalletException.php
@@ -12,10 +12,10 @@ class HyperwalletException extends \Exception {
      * Creates a instance of the HyperwalletException
      *
      * @param string $message The error message
-     * @param int|null $code The error code
+     * @param int $code The error code
      * @param \Exception|null $previous The original exception
      */
-    public function __construct($message, $code = null, \Exception $previous = null) {
+    public function __construct($message = "", $code = 0, \Exception $previous = null) {
         parent::__construct($message, $code, $previous);
     }
 

--- a/src/Hyperwallet/Hyperwallet.php
+++ b/src/Hyperwallet/Hyperwallet.php
@@ -10,7 +10,7 @@ use Hyperwallet\Model\BankAccount;
 use Hyperwallet\Model\BankAccountStatusTransition;
 use Hyperwallet\Model\BankCard;
 use Hyperwallet\Model\BankCardStatusTransition;
-use Hyperwallet\Model\HyperwalletVerificationDocument;
+use Hyperwallet\Model\HyperWalletVerificationDocument;
 use Hyperwallet\Model\HyperwalletVerificationDocumentReason;
 use Hyperwallet\Model\HyperwalletVerificationDocumentCollection;
 use Hyperwallet\Model\HyperwalletVerificationDocumentReasonCollection;
@@ -101,7 +101,7 @@ class Hyperwallet {
                     }
                     $dVal["reasons"] = new HyperwalletVerificationDocumentReasonCollection(...$reasons);
                 }
-                $dVal = new HyperwalletVerificationDocument($dVal);
+                $dVal = new HyperWalletVerificationDocument($dVal);
             }
             $bodyResponse["documents"] = new HyperwalletVerificationDocumentCollection(...$documents);
         }

--- a/src/Hyperwallet/Model/HyperWalletVerificationDocument.php
+++ b/src/Hyperwallet/Model/HyperWalletVerificationDocument.php
@@ -14,7 +14,7 @@ namespace Hyperwallet\Model;
  *
  * @package Hyperwallet\Model
  */
-class HyperwalletVerificationDocument extends BaseModel {
+class HyperWalletVerificationDocument extends BaseModel {
 
     /**
      * @internal
@@ -111,7 +111,7 @@ class HyperwalletVerificationDocument extends BaseModel {
  */
 class HyperwalletVerificationDocumentCollection {
 
-    public function __construct(HyperwalletVerificationDocument ...$documents) {
+    public function __construct(HyperWalletVerificationDocument ...$documents) {
         $this->documents = $documents;
     }
 

--- a/src/Hyperwallet/Model/HyperWalletVerificationDocument.php
+++ b/src/Hyperwallet/Model/HyperWalletVerificationDocument.php
@@ -119,8 +119,8 @@ class HyperwalletVerificationDocumentCollection {
         return $this->documents;
     }
    
-    public function getIterator() : ArrayIterator {
-        return new ArrayIterator($this->documents);
+    public function getIterator() {
+        return new \ArrayIterator($this->documents);
     }
    
 }

--- a/src/Hyperwallet/Model/HyperwalletVerificationDocumentReason.php
+++ b/src/Hyperwallet/Model/HyperwalletVerificationDocumentReason.php
@@ -77,8 +77,8 @@ class HyperwalletVerificationDocumentReasonCollection {
         return $this->reasons;
     }
    
-    public function getIterator() : ArrayIterator {
-        return new ArrayIterator($this->reasons);
+    public function getIterator() {
+        return new \ArrayIterator($this->reasons);
     }
    
 }

--- a/src/Hyperwallet/Util/ApiClient.php
+++ b/src/Hyperwallet/Util/ApiClient.php
@@ -3,13 +3,10 @@ namespace Hyperwallet\Util;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\BadResponseException;
 use GuzzleHttp\Exception\ConnectException;
-use GuzzleHttp\UriTemplate\UriTemplate;
 use Hyperwallet\Exception\HyperwalletApiException;
 use Hyperwallet\Exception\HyperwalletException;
 use Hyperwallet\Model\BaseModel;
 use Hyperwallet\Response\ErrorResponse;
-use Hyperwallet\Util\HyperwalletEncryption;
-use Hyperwallet\Util\HyperwalletUUID;
 
 /**
  * The internal API client
@@ -23,7 +20,7 @@ class ApiClient {
      *
      * @var string
      */
-    const VERSION = '1.7.1';
+    const VERSION = '1.7.3';
 
     /**
      * The Guzzle http client
@@ -95,7 +92,7 @@ class ApiClient {
      * @throws HyperwalletApiException
      */
     public function doPost($partialUrl, array $uriParams, BaseModel $data = null, array $query = array(), array $headers = array()) {
-        return $this->doRequest('POST', $partialUrl, $uriParams, array(
+       return $this->doRequest('POST', $partialUrl, $uriParams, array(
             'query' => $query,
             'body' => $data ? \GuzzleHttp\json_encode($data->getPropertiesForCreate(), JSON_FORCE_OBJECT) : '{}',
             'headers' => array_merge($headers, array(
@@ -154,7 +151,7 @@ class ApiClient {
      */
     private function doRequest($method, $url, array $urlParams, array $options) {
         try {
-            $uri = new UriTemplate();
+            $uri = new HyperwalletUriTemplate();
             if (!isset($options['headers'])) {
                 $options[] = array('headers' => array());
             }

--- a/src/Hyperwallet/Util/HyperwalletUUID.php
+++ b/src/Hyperwallet/Util/HyperwalletUUID.php
@@ -1,22 +1,7 @@
 <?php
 namespace Hyperwallet\Util;
-use GuzzleHttp\Client;
-use GuzzleHttp\Exception\BadResponseException;
-use GuzzleHttp\Exception\ConnectException;
-use GuzzleHttp\UriTemplate\UriTemplate;
-use Hyperwallet\Exception\HyperwalletApiException;
+
 use Hyperwallet\Exception\HyperwalletException;
-use Hyperwallet\Model\BaseModel;
-use Hyperwallet\Response\ErrorResponse;
-use Composer\Autoload\ClassLoader;
-use phpseclib\Crypt\RSA;
-use phpseclib\Math\BigInteger;
-use phpseclib\Crypt\Hash;
-use JOSE_URLSafeBase64;
-use JOSE_JWS;
-use JOSE_JWE;
-use JOSE_JWK;
-use JOSE_JWT;
 
 /**
  * The encryption service for Hyperwallet client's requests/responses

--- a/src/Hyperwallet/Util/HyperwalletUriTemplate.php
+++ b/src/Hyperwallet/Util/HyperwalletUriTemplate.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Hyperwallet\Util;
+
+/**
+ * A simple implementation of https://www.rfc-editor.org/rfc/rfc6570 for expanding Hyperwallet
+ * Uniform Resource Identifier (URI) Template.
+ *
+ * This class was created to allow the Hyperwallet SDK to support by PHP 5.6 and latest version
+ * @package Hyperwallet\Util
+ */
+final class HyperwalletUriTemplate
+{
+
+    /**
+     * Regex pattern to find variable identifier defined by pair of braces ('{', '}').
+     * e.g. {var}
+     */
+    const PATTERN = '/\{([^\}]+)\}/';
+
+    /**
+     * Processes URI Template
+     *
+     * This implementation will replace simple key defined in pair of braces ('{', '}') and replaced for the associate
+     * variable value.
+     *
+     * E.g. $uriTemplate = `test/{var-a}/{var-b}`, $variables = array('var-a' => 'testA', 'var-b' => 'testB') will return
+     * test/testA/testB
+     *
+     * @param string $uriTemplate the URI Template is a string that
+     * contains zero or more embedded variable expressions delimited by pair of braces ('{', '}').
+     * @param array $variables the variable identifiers for associating values within a template
+     * processor
+     * @return string
+     */
+    public function expand($uriTemplate, array $variables)
+    {
+        if (!$variables || strpos($uriTemplate, '{') === false) {
+            // skip processing
+            return $uriTemplate;
+        }
+
+        return \preg_replace_callback(
+            self::PATTERN,
+            self::buildProcessMatchResult($variables),
+            $uriTemplate
+        );
+    }
+
+    /**
+     * Evaluates the match result and find the associated value from the defined variables
+     * @param array $matches the match results
+     * @param array $variables the variable identifiers for associating values within a template
+     * processor
+     * @return mixed
+     */
+    private static function processMatchResult(array $matches, array $variables)
+    {
+        if (!isset($variables[$matches[1]])) {
+            // missing variable definition, return the match key
+            return $matches[0];
+        }
+
+        return $variables[$matches[1]];
+    }
+
+    /**
+     * Builds an anonymous functions to process the match result
+     * @param array $variables
+     * @return \Closure
+     */
+    private static function buildProcessMatchResult(array $variables)
+    {
+        return static function (array $matches) use ($variables) {
+            return self::processMatchResult($matches, $variables);
+        };
+    }
+}

--- a/tests/Hyperwallet/Tests/HyperwalletTest.php
+++ b/tests/Hyperwallet/Tests/HyperwalletTest.php
@@ -31,7 +31,7 @@ use Hyperwallet\Model\VenmoAccountStatusTransition;
 use Hyperwallet\Response\ErrorResponse;
 use Hyperwallet\Util\ApiClient;
 
-class HyperwalletTest extends \PHPUnit_Framework_TestCase {
+class HyperwalletTest extends \PHPUnit\Framework\TestCase {
 
     public function testConstructor_throwErrorIfUsernameIsEmpty() {
         try {

--- a/tests/Hyperwallet/Tests/Model/BaseModelTest.php
+++ b/tests/Hyperwallet/Tests/Model/BaseModelTest.php
@@ -3,7 +3,7 @@ namespace Hyperwallet\Tests\Model;
 
 use Hyperwallet\Model\BaseModel;
 
-class BaseModelTest extends \PHPUnit_Framework_TestCase {
+class BaseModelTest extends \PHPUnit\Framework\TestCase {
 
     public function testMagicGetter() {
         $data = array(

--- a/tests/Hyperwallet/Tests/Model/ModelTestCase.php
+++ b/tests/Hyperwallet/Tests/Model/ModelTestCase.php
@@ -1,7 +1,7 @@
 <?php
 namespace Hyperwallet\Tests\Model;
 
-abstract class ModelTestCase extends \PHPUnit_Framework_TestCase {
+abstract class ModelTestCase extends \PHPUnit\Framework\TestCase {
 
     /**
      * @var \ReflectionClass
@@ -25,8 +25,9 @@ abstract class ModelTestCase extends \PHPUnit_Framework_TestCase {
 
     protected abstract function getModelName();
 
-    public function setUp() {
-        parent::setUp();
+    public function __construct($name = null, array $data = [], $dataName = '')
+    {
+        parent::__construct($name, $data, $dataName);
         $this->init();
     }
 

--- a/tests/Hyperwallet/Tests/Response/ErrorResponseTest.php
+++ b/tests/Hyperwallet/Tests/Response/ErrorResponseTest.php
@@ -4,7 +4,7 @@ namespace Hyperwallet\Tests\Response;
 use Hyperwallet\Model\Error;
 use Hyperwallet\Response\ErrorResponse;
 
-class ErrorResponseTest extends \PHPUnit_Framework_TestCase {
+class ErrorResponseTest extends \PHPUnit\Framework\TestCase {
 
     public function testBodyParsing() {
         $errorResponse = new ErrorResponse(200, array(

--- a/tests/Hyperwallet/Tests/Response/ListResponseTest.php
+++ b/tests/Hyperwallet/Tests/Response/ListResponseTest.php
@@ -3,7 +3,7 @@ namespace Hyperwallet\Tests\Response;
 
 use Hyperwallet\Response\ListResponse;
 
-class ListResponseTest extends \PHPUnit_Framework_TestCase {
+class ListResponseTest extends \PHPUnit\Framework\TestCase {
 
     public function testBodyParsing_noContent() {
         $listResponse = new ListResponse(array(), function ($body) {

--- a/tests/Hyperwallet/Tests/Util/ApiClientTest.php
+++ b/tests/Hyperwallet/Tests/Util/ApiClientTest.php
@@ -13,7 +13,7 @@ use Hyperwallet\Model\BaseModel;
 use Hyperwallet\Util\ApiClient;
 use Hyperwallet\Util\HyperwalletEncryption;
 
-class ApiClientTest extends \PHPUnit_Framework_TestCase {
+class ApiClientTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @var array

--- a/tests/Hyperwallet/Tests/Util/HyperwalletEncryptionTest.php
+++ b/tests/Hyperwallet/Tests/Util/HyperwalletEncryptionTest.php
@@ -4,7 +4,7 @@ namespace Hyperwallet\Tests\Util;
 use Hyperwallet\Util\HyperwalletEncryption;
 use Hyperwallet\Exception\HyperwalletException;
 
-class HyperwalletEncryptionTest extends \PHPUnit_Framework_TestCase {
+class HyperwalletEncryptionTest extends \PHPUnit\Framework\TestCase {
 
     public function testShouldSuccessfullyEncryptAndDecryptTextMessage() {
         // Setup data

--- a/tests/Hyperwallet/Tests/Util/HyperwalletUUIDTest.php
+++ b/tests/Hyperwallet/Tests/Util/HyperwalletUUIDTest.php
@@ -4,7 +4,7 @@ namespace Hyperwallet\Tests\Util;
 use Hyperwallet\Exception\HyperwalletException;
 use Hyperwallet\Util\HyperwalletUUID;
 
-class HyperwalletUUIDTest extends \PHPUnit_Framework_TestCase {
+class HyperwalletUUIDTest extends \PHPUnit\Framework\TestCase {
 
     public function testShouldSuccessfullyGenerateRandomUUIDs() {
         // Setup data

--- a/tests/Hyperwallet/Tests/Util/HyperwalletUriTemplateTest.php
+++ b/tests/Hyperwallet/Tests/Util/HyperwalletUriTemplateTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Hyperwallet\Tests\Util;
+
+use Hyperwallet\Util\HyperwalletUriTemplate;
+
+class HyperwalletUriTemplateTest extends \PHPUnit\Framework\TestCase {
+
+    public function testShouldProcessUriTemplate() {
+        $uriTemplate = '/users/{user-token}/paypal-accounts/{paypal-account-token}/status-transitions';
+        $userToken = "000-000-000-0";
+        $payPalAccountToken = "1111-111-11-11";
+        $urlParams = array(
+            'user-token' => $userToken,
+            'paypal-account-token' => $payPalAccountToken
+        );
+
+        $uri = new HyperwalletUriTemplate();
+        $result = $uri->expand($uriTemplate, $urlParams);
+
+        $this->assertEquals('/users/000-000-000-0/paypal-accounts/1111-111-11-11/status-transitions', $result);
+    }
+
+    public function testShouldReturnMissingVariableIdentifier() {
+        $uriTemplate = '/users/{user-token}/paypal-accounts/{paypal-account-token}/status';
+        $userToken = "000-000-000-0";
+        $urlParams = array(
+            'user-token' => $userToken
+        );
+
+        $uri = new HyperwalletUriTemplate();
+        $result = $uri->expand($uriTemplate, $urlParams);
+
+        $this->assertEquals('/users/000-000-000-0/paypal-accounts/{paypal-account-token}/status', $result);
+    }
+
+    public function testShouldReturnAllMissingVariableIdentifier() {
+        $uriTemplate = '/users/{user-token}/paypal-accounts/{paypal-account-token}/status';
+        $token = "000-000-000-0";
+        $urlParams = array(
+            'token' => $token
+        );
+
+        $uri = new HyperwalletUriTemplate();
+        $result = $uri->expand($uriTemplate, $urlParams);
+
+        $this->assertEquals('/users/{user-token}/paypal-accounts/{paypal-account-token}/status', $result);
+    }
+
+    public function testShouldSkipProcessWhenURLParamsIsEmpty() {
+        $uriTemplate = '/users/{user-token}/paypal-accounts/{paypal-account-token}/status';
+        $urlParams = array();
+
+        $uri = new HyperwalletUriTemplate();
+        $result = $uri->expand($uriTemplate, $urlParams);
+
+        $this->assertEquals('/users/{user-token}/paypal-accounts/{paypal-account-token}/status', $result);
+    }
+
+    public function testShouldSkipProcessWhenUriTemplateDoesHaveStartBrace() {
+        $uriTemplate = '/users/status';
+        $urlParams = array();
+
+        $uri = new HyperwalletUriTemplate();
+        $result = $uri->expand($uriTemplate, $urlParams);
+
+        $this->assertEquals('/users/status', $result);
+    }
+
+}


### PR DESCRIPTION
Cherry pick V4 change  f9eb75a404731752652d340eb167bf97ee073af0 from the branch
 [`feature/DTSERWONE-1083 - V4 Support php versions (#117)`](https://github.com/hyperwallet/php-sdk/pull/117)

# Summary:
Enhanced the PHP-SDK to support PHP version build from 5.6 to 8.1

- Introduce Hyperwallet URI Template
- Introduce GitHubAction to test PHP version from 5.6 to latest
- Address PHP Unit test compatibility


Github Action Result:
https://github.com/hyperwallet/php-sdk/actions/runs/2922755967
<img width="1609" alt="Screen Shot 2022-08-24 at 3 44 18 PM" src="https://user-images.githubusercontent.com/107439697/186536683-014945a1-ba59-44fe-8a84-f10360aecc39.png">


https://coveralls.io/builds/51925854
<img width="1614" alt="Screen Shot 2022-08-24 at 3 47 10 PM" src="https://user-images.githubusercontent.com/107439697/186537032-e744db4c-9016-4896-8b97-5aa1260d2a75.png">

