### PR TITLE
feature/DTSERWONE-10831083  Address PHP 8.1 issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,44 @@ on:
       - bugfix/**
 
 jobs:
+  static-analisis:
+    name: Static-analysis
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      fail-fast: false
+      matrix:
+        operating-system: [ 'ubuntu-latest' ]
+        # The 5.6 PHP will be validated by 7.0 since the Static analysis tools is only supported by 7.x and latest
+        php-versions: [ '7.0','7.1', '7.2', '7.3', '7.4', '8.0', '8.1' ]
+
+    steps:
+      - uses: actions/checkout@master
+
+      #sets up the PHP version
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+          coverage: xdebug
+
+      #validate composer files
+      - name: Validate composer.json and composer.lock
+        run: composer validate
+
+      #get dependencies
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress --no-suggest
+
+      #get static analysis tool
+      - name: Install static analysis tool
+        run: |
+          composer require --dev phpstan/phpstan 
+
+      #evaluate the code
+      - name: Run static analysis tool
+        run: |
+          vendor/bin/phpstan analyse -l 1 src/Hyperwallet tests
+
   tests:
     name: Tests
     runs-on: ${{ matrix.operating-system }}
@@ -28,6 +66,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
 
+      #sets up the PHP version
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:

--- a/src/Hyperwallet/Response/ErrorResponse.php
+++ b/src/Hyperwallet/Response/ErrorResponse.php
@@ -40,7 +40,7 @@ class ErrorResponse implements \Countable, \ArrayAccess {
     public function __construct($statusCode, array $errors) {
         $this->statusCode = $statusCode;
         $this->errors = array_map(function ($error) {
-            if (!isset($relatedResources) && isset($error['relatedResources'])) {
+            if (!isset($this->relatedResources) && isset($error['relatedResources'])) {
                 $this->relatedResources = $error['relatedResources'];
             }
             return new Error($error);
@@ -84,7 +84,11 @@ class ErrorResponse implements \Countable, \ArrayAccess {
      * <p>
      * The return value is cast to an integer.
      * @since 5.1.0
+     *
+     * Note: Temporarily suppress the required return type, to keep compatibility with PHP 5.6
+     * the #[\ReturnTypeWillChange] must be removed once 5.6
      */
+    #[\ReturnTypeWillChange]
     public function count() {
         return count($this->errors);
     }
@@ -102,7 +106,11 @@ class ErrorResponse implements \Countable, \ArrayAccess {
      * <p>
      * The return value will be casted to boolean if non-boolean was returned.
      * @since 5.0.0
+     *
+     * Note: Temporarily suppress the required return type, to keep compatibility with PHP 5.6
+     * the #[\ReturnTypeWillChange] must be removed once 5.6
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset) {
         return isset($this->errors[$offset]);
     }
@@ -117,7 +125,11 @@ class ErrorResponse implements \Countable, \ArrayAccess {
      * </p>
      * @return mixed Can return all value types.
      * @since 5.0.0
+     *
+     * Note: Temporarily suppress the required return type, to keep compatibility with PHP 5.6
+     * the #[\ReturnTypeWillChange] must be removed once 5.6
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset) {
         return $this->errors[$offset];
     }
@@ -135,7 +147,11 @@ class ErrorResponse implements \Countable, \ArrayAccess {
      * </p>
      * @return void
      * @since 5.0.0
+     *
+     * Note: Temporarily suppress the required return type, to keep compatibility with PHP 5.6
+     * the #[\ReturnTypeWillChange] must be removed once 5.6
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value) {
         $this->errors[$offset] = $value;
     }
@@ -150,9 +166,12 @@ class ErrorResponse implements \Countable, \ArrayAccess {
      * </p>
      * @return void
      * @since 5.0.0
+     *
+     * Note: Temporarily suppress the required return type, to keep compatibility with PHP 5.6
+     * the #[\ReturnTypeWillChange] must be removed once 5.6
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset) {
         unset($this->errors[$offset]);
     }
-
 }

--- a/src/Hyperwallet/Response/ListResponse.php
+++ b/src/Hyperwallet/Response/ListResponse.php
@@ -87,7 +87,7 @@ class ListResponse implements \Countable , \ArrayAccess{
     /**
      * Get the Total number of Model's
      *
-     * @var int
+     * @return int
      */
     public function getLimit() {
         return $this->limit;
@@ -96,7 +96,7 @@ class ListResponse implements \Countable , \ArrayAccess{
     /**
      * Get Has Next Page of Model's
      *
-     * @var boolean
+     * @return boolean
      */
     public function getHasNextPage() {
         return $this->hasNextPage;
@@ -105,7 +105,7 @@ class ListResponse implements \Countable , \ArrayAccess{
     /**
      * Get Has Previous Page of Model's
      *
-     * @var boolean
+     * @return boolean
      */
     public function getHasPreviousPage() {
         return $this->hasPreviousPage;
@@ -122,7 +122,11 @@ class ListResponse implements \Countable , \ArrayAccess{
      * <p>
      * The return value is cast to an integer.
      * @since 5.1.0
+     *
+     * Note: Temporarily suppress the required return type, to keep compatibility with PHP 5.6
+     * the #[\ReturnTypeWillChange] must be removed once 5.6
      */
+    #[\ReturnTypeWillChange]
     public function count() {
         return count($this->data);
     }
@@ -139,7 +143,11 @@ class ListResponse implements \Countable , \ArrayAccess{
      * <p>
      * The return value will be casted to boolean if non-boolean was returned.
      * @since 5.0.0
+     *
+     * Note: Temporarily suppress the required return type, to keep compatibility with PHP 5.6
+     * the #[\ReturnTypeWillChange] must be removed once 5.6
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset) {
         return isset($this->data[$offset]);
     }
@@ -154,7 +162,11 @@ class ListResponse implements \Countable , \ArrayAccess{
      * </p>
      * @return mixed Can return all value types.
      * @since 5.0.0
+     *
+     * Note: Temporarily suppress the required return type, to keep compatibility with PHP 5.6
+     * the #[\ReturnTypeWillChange] must be removed once 5.6
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset) {
         return $this->data[$offset];
     }
@@ -172,7 +184,11 @@ class ListResponse implements \Countable , \ArrayAccess{
      * </p>
      * @return void
      * @since 5.0.0
+     *
+     * Note: Temporarily suppress the required return type, to keep compatibility with PHP 5.6
+     * the #[\ReturnTypeWillChange] must be removed once 5.6
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value) {
         $this->data[$offset] = $value;
     }
@@ -187,7 +203,11 @@ class ListResponse implements \Countable , \ArrayAccess{
      * </p>
      * @return void
      * @since 5.0.0
+     *
+     * Note: Temporarily suppress the required return type, to keep compatibility with PHP 5.6
+     * the #[\ReturnTypeWillChange] must be removed once 5.6
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset) {
         unset($this->data[$offset]);
     }

--- a/tests/Hyperwallet/Tests/HyperwalletTest.php
+++ b/tests/Hyperwallet/Tests/HyperwalletTest.php
@@ -705,7 +705,7 @@ class HyperwalletTest extends \PHPUnit\Framework\TestCase {
         $client = new Hyperwallet('test-username', 'test-password', 'test-program-token');
         $apiClientMock = $this->createAndInjectApiClientMock($client);
 
-        \Phake::when($apiClientMock)->doGet('/rest/v4/users/{user-token}/paper-checks', array('user-token' => 'test-user-token'), array())->thenReturn(array('limit' => 1,'limit' => 1,'hasNextPage' => false ,'hasPreviousPage' => false,'links' => 'links', 'data' => array()));
+        \Phake::when($apiClientMock)->doGet('/rest/v4/users/{user-token}/paper-checks', array('user-token' => 'test-user-token'), array())->thenReturn(array('limit' => 1,'hasNextPage' => false ,'hasPreviousPage' => false,'links' => 'links', 'data' => array()));
 
         // Run test
         $paperCheckList = $client->listPaperChecks('test-user-token');
@@ -4233,6 +4233,7 @@ class HyperwalletTest extends \PHPUnit\Framework\TestCase {
         \Phake::when($apiClientMock)->doPut('/rest/v4/users/{user-token}', array('user-token' => 'test-user-token'), $user, array())->thenReturn(array("status"=> User::STATUS_PRE_ACTIVATED, 'verificationStatus'=> User::VERIFICATION_STATUS_REQUIRED));
         \Phake::when($apiClientMock)->doGet('/rest/v4/users/{user-token}', array('user-token' => 'test-user-token'), array())->thenReturn(array("status"=> User::STATUS_PRE_ACTIVATED, 'verificationStatus'=> User::VERIFICATION_STATUS_REQUIRED));
 
+        $responseUser = null;
         // Run test
         try {
             $responseUser = $client->updateVerificationStatus('test-user-token', User::VERIFICATION_STATUS_REQUESTED);
@@ -5112,6 +5113,7 @@ class HyperwalletTest extends \PHPUnit\Framework\TestCase {
             $uriParams, $queryParams)->thenReturn(array('token' => $refundToken));
 
         // Run test
+        $transferRefund = null;
         try {
             $transferRefund = $client->getTransferRefund($transferToken, $refundToken);
         } catch (HyperwalletArgumentException $e) {

--- a/tests/Hyperwallet/Tests/Model/ClientTokenTest.php
+++ b/tests/Hyperwallet/Tests/Model/ClientTokenTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Hyperwallet\Tests\Model;
 
-class AuthenticationTokenTest extends ModelTestCase {
+class ClientTokenTest extends ModelTestCase {
 
     protected function getModelName() {
         return 'AuthenticationToken';


### PR DESCRIPTION
Minor enhancements to address PHP 8.1 issue by running PHPStan Static Analysis Tool like:
- Mandatory return type (this feature was introduced on 7.0)
- Mismatch class name and file
- Undefined type 