### PR TITLE
DTPAYETWO-761- Added 'isDefaultTransferMethod' attribute for default accounts(V3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ChangeLog
 =========
+1.7.4
+-------------------
+- Added attribute 'isDefaultTransferMethod' to identify default accounts.
+
 1.7.3
 -------------------
 - Enhanced the code base to support PHP build from version 5.6 to 8.x

--- a/src/Hyperwallet/Model/BankAccount.php
+++ b/src/Hyperwallet/Model/BankAccount.php
@@ -63,7 +63,7 @@ namespace Hyperwallet\Model;
  * @property string $stateProvince The state or province
  * @property string $country The country
  * @property string $postalCode The postal code
- * @property string $isDefaultTransferMethod The is default transfer method
+ * @property string $isDefaultTransferMethod The flag to denote default account
  *
  * @package Hyperwallet\Model
  */
@@ -1033,7 +1033,7 @@ class BankAccount extends BaseModel {
      * Set the is default transfer method
      *
      * @param string $isDefaultTransferMethod
-     * @return PayPalAccount
+     * @return BankAccount
      */
     public function setIsDefaultTransferMethod($isDefaultTransferMethod) {
         $this->isDefaultTransferMethod = $isDefaultTransferMethod;

--- a/src/Hyperwallet/Model/BankAccount.php
+++ b/src/Hyperwallet/Model/BankAccount.php
@@ -63,7 +63,7 @@ namespace Hyperwallet\Model;
  * @property string $stateProvince The state or province
  * @property string $country The country
  * @property string $postalCode The postal code
- * @property string $isDefaultTransferMethod The flag to denote default account
+ * @property bool $isDefaultTransferMethod The flag to denote default account
  *
  * @package Hyperwallet\Model
  */
@@ -1023,7 +1023,7 @@ class BankAccount extends BaseModel {
     /**
      * Get the is default transfer method
      *
-     * @return string
+     * @return bool
      */
     public function getIsDefaultTransferMethod() {
         return $this->isDefaultTransferMethod;
@@ -1032,7 +1032,7 @@ class BankAccount extends BaseModel {
     /**
      * Set the is default transfer method
      *
-     * @param string $isDefaultTransferMethod
+     * @param bool $isDefaultTransferMethod
      * @return BankAccount
      */
     public function setIsDefaultTransferMethod($isDefaultTransferMethod) {

--- a/src/Hyperwallet/Model/BankAccount.php
+++ b/src/Hyperwallet/Model/BankAccount.php
@@ -63,6 +63,7 @@ namespace Hyperwallet\Model;
  * @property string $stateProvince The state or province
  * @property string $country The country
  * @property string $postalCode The postal code
+ * @property string $isDefaultTransferMethod The is default transfer method
  *
  * @package Hyperwallet\Model
  */
@@ -1019,4 +1020,23 @@ class BankAccount extends BaseModel {
         return $this;
     }
 
+    /**
+     * Get the is default transfer method
+     *
+     * @return string
+     */
+    public function getIsDefaultTransferMethod() {
+        return $this->isDefaultTransferMethod;
+    }
+
+    /**
+     * Set the is default transfer method
+     *
+     * @param string $isDefaultTransferMethod
+     * @return PayPalAccount
+     */
+    public function setIsDefaultTransferMethod($isDefaultTransferMethod) {
+        $this->isDefaultTransferMethod = $isDefaultTransferMethod;
+        return $this;
+    }
 }

--- a/src/Hyperwallet/Model/BankCard.php
+++ b/src/Hyperwallet/Model/BankCard.php
@@ -20,7 +20,7 @@ namespace Hyperwallet\Model;
  * @property string $cvv The bank card cvv
  * @property \DateTime $dateOfExpiry The bank card expiry date
  * @property string $processingTime The processing time
- * @property string $isDefaultTransferMethod The flag to denote default account
+ * @property bool $isDefaultTransferMethod The flag to denote default account
  *
  * @package Hyperwallet\Model
  */
@@ -262,7 +262,7 @@ class BankCard extends BaseModel {
     /**
      * Get the is default transfer method
      *
-     * @return string
+     * @return bool
      */
     public function getIsDefaultTransferMethod() {
         return $this->isDefaultTransferMethod;
@@ -271,7 +271,7 @@ class BankCard extends BaseModel {
     /**
      * Set the is default transfer method
      *
-     * @param string $isDefaultTransferMethod
+     * @param bool $isDefaultTransferMethod
      * @return BankCard
      */
     public function setIsDefaultTransferMethod($isDefaultTransferMethod) {

--- a/src/Hyperwallet/Model/BankCard.php
+++ b/src/Hyperwallet/Model/BankCard.php
@@ -20,7 +20,7 @@ namespace Hyperwallet\Model;
  * @property string $cvv The bank card cvv
  * @property \DateTime $dateOfExpiry The bank card expiry date
  * @property string $processingTime The processing time
- * @property string $isDefaultTransferMethod The is default transfer method
+ * @property string $isDefaultTransferMethod The flag to denote default account
  *
  * @package Hyperwallet\Model
  */
@@ -272,7 +272,7 @@ class BankCard extends BaseModel {
      * Set the is default transfer method
      *
      * @param string $isDefaultTransferMethod
-     * @return PayPalAccount
+     * @return BankCard
      */
     public function setIsDefaultTransferMethod($isDefaultTransferMethod) {
         $this->isDefaultTransferMethod = $isDefaultTransferMethod;

--- a/src/Hyperwallet/Model/BankCard.php
+++ b/src/Hyperwallet/Model/BankCard.php
@@ -20,6 +20,7 @@ namespace Hyperwallet\Model;
  * @property string $cvv The bank card cvv
  * @property \DateTime $dateOfExpiry The bank card expiry date
  * @property string $processingTime The processing time
+ * @property string $isDefaultTransferMethod The is default transfer method
  *
  * @package Hyperwallet\Model
  */
@@ -258,4 +259,23 @@ class BankCard extends BaseModel {
         return $this;
     }
 
+    /**
+     * Get the is default transfer method
+     *
+     * @return string
+     */
+    public function getIsDefaultTransferMethod() {
+        return $this->isDefaultTransferMethod;
+    }
+
+    /**
+     * Set the is default transfer method
+     *
+     * @param string $isDefaultTransferMethod
+     * @return PayPalAccount
+     */
+    public function setIsDefaultTransferMethod($isDefaultTransferMethod) {
+        $this->isDefaultTransferMethod = $isDefaultTransferMethod;
+        return $this;
+    }
 }

--- a/src/Hyperwallet/Model/PaperCheck.php
+++ b/src/Hyperwallet/Model/PaperCheck.php
@@ -30,7 +30,7 @@ namespace Hyperwallet\Model;
  * @property string $gender The gender
  * @property string $governmentId The government id
  * @property string $governmentIdType The government id type
- * @property string $isDefaultTransferMethod The flag to denote default account
+ * @property bool $isDefaultTransferMethod The flag to denote default account
  * @property string $lastName The last name
  * @property string $middleName The middle name
  * @property string $mobileNumber The mobile number
@@ -420,7 +420,7 @@ class PaperCheck extends BaseModel {
     /**
      * Get the is default transfer method
      *
-     * @return string
+     * @return bool
      */
     public function getIsDefaultTransferMethod() {
         return $this->isDefaultTransferMethod;
@@ -429,7 +429,7 @@ class PaperCheck extends BaseModel {
     /**
      * Set the is default transfer method
      *
-     * @param string $isDefaultTransferMethod
+     * @param bool $isDefaultTransferMethod
      * @return PaperCheck
      */
     public function setIsDefaultTransferMethod($isDefaultTransferMethod) {

--- a/src/Hyperwallet/Model/PaperCheck.php
+++ b/src/Hyperwallet/Model/PaperCheck.php
@@ -30,7 +30,7 @@ namespace Hyperwallet\Model;
  * @property string $gender The gender
  * @property string $governmentId The government id
  * @property string $governmentIdType The government id type
- * @property string $isDefaultTransferMethod The is default transfer method
+ * @property string $isDefaultTransferMethod The flag to denote default account
  * @property string $lastName The last name
  * @property string $middleName The middle name
  * @property string $mobileNumber The mobile number

--- a/src/Hyperwallet/Model/PayPalAccount.php
+++ b/src/Hyperwallet/Model/PayPalAccount.php
@@ -10,7 +10,7 @@ namespace Hyperwallet\Model;
  * @property string $type The transfer method type
  * @property string $transferMethodCountry The transfer method country
  * @property string $transferMethodCurrency The transfer method currency
- * @property string $isDefaultTransferMethod The flag to denote default account
+ * @property bool $isDefaultTransferMethod The flag to denote default account
  * @property string $email The PayPal account email
 
  *
@@ -142,7 +142,7 @@ class PayPalAccount extends BaseModel {
     /**
      * Get the is default transfer method
      *
-     * @return string
+     * @return bool
      */
     public function getIsDefaultTransferMethod() {
         return $this->isDefaultTransferMethod;
@@ -151,7 +151,7 @@ class PayPalAccount extends BaseModel {
     /**
      * Set the is default transfer method
      *
-     * @param string $isDefaultTransferMethod
+     * @param bool $isDefaultTransferMethod
      * @return PayPalAccount
      */
     public function setIsDefaultTransferMethod($isDefaultTransferMethod) {

--- a/src/Hyperwallet/Model/PayPalAccount.php
+++ b/src/Hyperwallet/Model/PayPalAccount.php
@@ -10,7 +10,7 @@ namespace Hyperwallet\Model;
  * @property string $type The transfer method type
  * @property string $transferMethodCountry The transfer method country
  * @property string $transferMethodCurrency The transfer method currency
- * @property string $isDefaultTransferMethod The is default transfer method
+ * @property string $isDefaultTransferMethod The flag to denote default account
  * @property string $email The PayPal account email
 
  *

--- a/src/Hyperwallet/Model/PrepaidCard.php
+++ b/src/Hyperwallet/Model/PrepaidCard.php
@@ -19,6 +19,7 @@ namespace Hyperwallet\Model;
  * @property string $cardNumber The prepaid card number
  * @property string $cardBrand The prepaid card brand
  * @property \DateTime $dateOfExpiry The prepaid card expiry date
+ * @property string $isDefaultTransferMethod The is default transfer method
  *
  * @package Hyperwallet\Model
  */
@@ -195,6 +196,26 @@ class PrepaidCard extends BaseModel {
      */
     public function getDateOfExpiry() {
         return $this->dateOfExpiry ? new \DateTime($this->dateOfExpiry) : null;
+    }
+
+    /**
+     * Get the is default transfer method
+     *
+     * @return string
+     */
+    public function getIsDefaultTransferMethod() {
+        return $this->isDefaultTransferMethod;
+    }
+
+    /**
+     * Set the is default transfer method
+     *
+     * @param string $isDefaultTransferMethod
+     * @return PayPalAccount
+     */
+    public function setIsDefaultTransferMethod($isDefaultTransferMethod) {
+        $this->isDefaultTransferMethod = $isDefaultTransferMethod;
+        return $this;
     }
 
 }

--- a/src/Hyperwallet/Model/PrepaidCard.php
+++ b/src/Hyperwallet/Model/PrepaidCard.php
@@ -19,7 +19,7 @@ namespace Hyperwallet\Model;
  * @property string $cardNumber The prepaid card number
  * @property string $cardBrand The prepaid card brand
  * @property \DateTime $dateOfExpiry The prepaid card expiry date
- * @property string $isDefaultTransferMethod The flag to denote default account
+ * @property bool $isDefaultTransferMethod The flag to denote default account
  *
  * @package Hyperwallet\Model
  */
@@ -201,7 +201,7 @@ class PrepaidCard extends BaseModel {
     /**
      * Get the is default transfer method
      *
-     * @return string
+     * @return bool
      */
     public function getIsDefaultTransferMethod() {
         return $this->isDefaultTransferMethod;
@@ -210,7 +210,7 @@ class PrepaidCard extends BaseModel {
     /**
      * Set the is default transfer method
      *
-     * @param string $isDefaultTransferMethod
+     * @param bool $isDefaultTransferMethod
      * @return PrepaidCard
      */
     public function setIsDefaultTransferMethod($isDefaultTransferMethod) {

--- a/src/Hyperwallet/Model/PrepaidCard.php
+++ b/src/Hyperwallet/Model/PrepaidCard.php
@@ -19,7 +19,7 @@ namespace Hyperwallet\Model;
  * @property string $cardNumber The prepaid card number
  * @property string $cardBrand The prepaid card brand
  * @property \DateTime $dateOfExpiry The prepaid card expiry date
- * @property string $isDefaultTransferMethod The is default transfer method
+ * @property string $isDefaultTransferMethod The flag to denote default account
  *
  * @package Hyperwallet\Model
  */
@@ -211,7 +211,7 @@ class PrepaidCard extends BaseModel {
      * Set the is default transfer method
      *
      * @param string $isDefaultTransferMethod
-     * @return PayPalAccount
+     * @return PrepaidCard
      */
     public function setIsDefaultTransferMethod($isDefaultTransferMethod) {
         $this->isDefaultTransferMethod = $isDefaultTransferMethod;

--- a/src/Hyperwallet/Model/TransferMethod.php
+++ b/src/Hyperwallet/Model/TransferMethod.php
@@ -74,7 +74,7 @@ namespace Hyperwallet\Model;
  * @property string $stateProvince The state or province
  * @property string $country The country
  * @property string $postalCode The postal code
- * @property string $isDefaultTransferMethod The is default transfer method
+ * @property string $isDefaultTransferMethod The flag to denote default account
  *
  * @package Hyperwallet\Model
  */
@@ -1135,7 +1135,7 @@ class TransferMethod extends BaseModel {
      * Set the is default transfer method
      *
      * @param string $isDefaultTransferMethod
-     * @return PayPalAccount
+     * @return TransferMethod
      */
     public function setIsDefaultTransferMethod($isDefaultTransferMethod) {
         $this->isDefaultTransferMethod = $isDefaultTransferMethod;

--- a/src/Hyperwallet/Model/TransferMethod.php
+++ b/src/Hyperwallet/Model/TransferMethod.php
@@ -21,9 +21,9 @@ namespace Hyperwallet\Model;
  * @property \DateTime $dateOfExpiry The prepaid card expiry date
  *
  * @property string $email The email associated with the paypal account
- * 
+ *
  * @property string $accountId The accountId associated with the venmo account
- * 
+ *
  * @property string $bankName The bank name
  * @property string $bankId The bank id
  * @property string $branchName The branch name
@@ -74,6 +74,7 @@ namespace Hyperwallet\Model;
  * @property string $stateProvince The state or province
  * @property string $country The country
  * @property string $postalCode The postal code
+ * @property string $isDefaultTransferMethod The is default transfer method
  *
  * @package Hyperwallet\Model
  */
@@ -87,7 +88,7 @@ class TransferMethod extends BaseModel {
      * @var string[]
      */
     private static $READ_ONLY_FIELDS = array('token', 'status', 'cardType', 'cardNumber', 'cardBrand', 'dateOfExpiry', 'createdOn', 'email', 'accountId');
-    
+
     public static function FILTERS_ARRAY() {
         return array('status', 'type', 'createdBefore', 'createdAfter', 'sortBy', 'offset', 'limit');
     }
@@ -221,7 +222,7 @@ class TransferMethod extends BaseModel {
     public function getAccountId() {
         return $this->accountId;
     }
-    
+
     /**
      * Get the bank account id
      *
@@ -1121,4 +1122,23 @@ class TransferMethod extends BaseModel {
         return $this;
     }
 
+    /**
+     * Get the is default transfer method
+     *
+     * @return string
+     */
+    public function getIsDefaultTransferMethod() {
+        return $this->isDefaultTransferMethod;
+    }
+
+    /**
+     * Set the is default transfer method
+     *
+     * @param string $isDefaultTransferMethod
+     * @return PayPalAccount
+     */
+    public function setIsDefaultTransferMethod($isDefaultTransferMethod) {
+        $this->isDefaultTransferMethod = $isDefaultTransferMethod;
+        return $this;
+    }
 }

--- a/src/Hyperwallet/Model/TransferMethod.php
+++ b/src/Hyperwallet/Model/TransferMethod.php
@@ -74,7 +74,7 @@ namespace Hyperwallet\Model;
  * @property string $stateProvince The state or province
  * @property string $country The country
  * @property string $postalCode The postal code
- * @property string $isDefaultTransferMethod The flag to denote default account
+ * @property bool $isDefaultTransferMethod The flag to denote default account
  *
  * @package Hyperwallet\Model
  */
@@ -1125,7 +1125,7 @@ class TransferMethod extends BaseModel {
     /**
      * Get the is default transfer method
      *
-     * @return string
+     * @return bool
      */
     public function getIsDefaultTransferMethod() {
         return $this->isDefaultTransferMethod;
@@ -1134,7 +1134,7 @@ class TransferMethod extends BaseModel {
     /**
      * Set the is default transfer method
      *
-     * @param string $isDefaultTransferMethod
+     * @param bool $isDefaultTransferMethod
      * @return TransferMethod
      */
     public function setIsDefaultTransferMethod($isDefaultTransferMethod) {

--- a/src/Hyperwallet/Model/VenmoAccount.php
+++ b/src/Hyperwallet/Model/VenmoAccount.php
@@ -11,7 +11,7 @@ namespace Hyperwallet\Model;
  * @property string $type The transfer method type
  * @property string $transferMethodCountry The transfer method country
  * @property string $transferMethodCurrency The transfer method currency
- * @property string $isDefaultTransferMethod The is default transfer method
+ * @property string $isDefaultTransferMethod The flag to denote default account
  * @property string $accountId The Venmo account
  *
  * @package Hyperwallet\Model

--- a/src/Hyperwallet/Model/VenmoAccount.php
+++ b/src/Hyperwallet/Model/VenmoAccount.php
@@ -11,7 +11,7 @@ namespace Hyperwallet\Model;
  * @property string $type The transfer method type
  * @property string $transferMethodCountry The transfer method country
  * @property string $transferMethodCurrency The transfer method currency
- * @property string $isDefaultTransferMethod The flag to denote default account
+ * @property bool $isDefaultTransferMethod The flag to denote default account
  * @property string $accountId The Venmo account
  *
  * @package Hyperwallet\Model
@@ -140,7 +140,7 @@ class VenmoAccount extends BaseModel {
     /**
      * Get the is default transfer method
      *
-     * @return string
+     * @return bool
      */
     public function getIsDefaultTransferMethod() {
         return $this->isDefaultTransferMethod;
@@ -149,7 +149,7 @@ class VenmoAccount extends BaseModel {
     /**
      * Set the is default transfer method
      *
-     * @param string $isDefaultTransferMethod
+     * @param bool $isDefaultTransferMethod
      * @return VenmoAccount
      */
     public function setIsDefaultTransferMethod($isDefaultTransferMethod) {


### PR DESCRIPTION
Design: https://engineering.paypalcorp.com/confluence/display/Payouts/Default+Transfer+Method+in+EA+responses

The change is to refine all of the external accounts API responses (GET, GET ALL) to include a "isDefaultTransferMethod" attribute holding a boolean value and is displayed only when the attribute is true which helps in determining the default account to which payment is made.