### PR TITLE
Update ListResponse.php

### DIFF
--- a/src/Hyperwallet/Response/ListResponse.php
+++ b/src/Hyperwallet/Response/ListResponse.php
@@ -59,7 +59,7 @@ class ListResponse implements \Countable , \ArrayAccess{
             $this->hasNextPage = $body['hasNextPage'];
             $this->hasPreviousPage = $body['hasPreviousPage'];
             $this->limit = $body['limit'];
-            $this->links = $body['links'];
+            $this->links = $body['links'] ?? $this->links;
             $this->data = array_map(function ($item) use ($convertEntry) {
                 return $convertEntry($item);
             }, $body['data']);


### PR DESCRIPTION
Not all API response body payloads contain the links key, which throws an exception.

Example:

```php
<?php

use Hyperwallet\Hyperwallet;

$hyperwallet = new Hyperwallet('username', 'password');

$hyperwallet->listBalancesForAccount('prg-xxxx','act-xxxx');
```

```
 ErrorException 

  Undefined array key "links"

  at vendor/hyperwallet/sdk/src/Hyperwallet/Response/ListResponse.php:62
     58▕         } else {
     59▕             $this->hasNextPage = $body['hasNextPage'];
     60▕             $this->hasPreviousPage = $body['hasPreviousPage'];
     61▕             $this->limit = $body['limit'];
  ➜  62▕             $this->links = $body['links'];
     63▕             $this->data = array_map(function ($item) use ($convertEntry) {
     64▕                 return $convertEntry($item);
     65▕             }, $body['data']);
     66▕         }
```

The above change resolves this:

```
Hyperwallet\Response\ListResponse {#1282
  -limit: 100
  -hasNextPage: false
  -hasPreviousPage: false
  -data: array:1 [
    0 => Hyperwallet\Model\Balance {#1286
      -properties: array:2 [
        "currency" => "USD"
        "amount" => "1234.56"
      ]
      -updatedProperties: []
      -readOnlyProperties: array:2 [
        0 => "currency"
        1 => "amount"
      ]
    }
  ]
}
```